### PR TITLE
refs #13270 added cache stage; added tests testcontainer service with docker.sock

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -10,18 +10,9 @@ COPY --chown=gradle:gradle ./$LIQUIBASE_DIR/liquibase.properties $CACHE_CODE/$LI
 WORKDIR $CACHE_CODE
 RUN gradle dependencies --no-daemon --build-cache
 
-FROM gradle:8.10.1-jdk21 AS build
+FROM gradle:8.10.1-jdk21 as test
 ARG BUILD_HOME=/server
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . $BUILD_HOME/
 WORKDIR $BUILD_HOME/
-RUN gradle build -i --stacktrace -x test --build-cache
 
-FROM eclipse-temurin:21-jre-alpine
-
-ARG BUILD_HOME=/server
-WORKDIR /app
-
-COPY --from=build $BUILD_HOME/build/libs/*.jar /app/os-test-0.0.1-SNAPSHOT-plain.jar
-
-CMD ["java", "-jar", "/app/os-test-0.0.1-SNAPSHOT-plain.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,12 @@
 services:
+  test:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.test
+    volumes: 
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: /bin/sh -c "gradle test; sleep infinity"
+
   backend:
     build:
       context: .
@@ -11,6 +19,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: password
     depends_on:
       - postgres
+      - test
 
   postgres:
     image: postgres:16


### PR DESCRIPTION
Read the title.

Adding testcontainers step inside docker build process is not an option, because it looks ugly and counter-intuitive.

Instead, added working testcontainers container, which persists and, if one wants, they can extract logs from there with some extra steps like redirecting output to file  (p.e. github ci).

Also shortened deploy time with additional stage in multistage build, that caches dependencies.